### PR TITLE
add htmx trigger to refresh chart after custom event and time delay

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func main() {
 	r.Get("/weigh_in/new", cfg.handlerWeighInNew)
 	r.Get("/landing_page", cfg.handlerLandingPage)
 	r.Post("/weigh_in/create", cfg.handlerCreateWeighIn)
+	r.Get("/get_chart_data", cfg.handlerRefreshChart)
 
 	// Serve static files
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.Dir("./static"))))

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,10 +15,7 @@
 		<!-- Responsive wrapper -->
 		<div class="flex flex-col md:flex-row w-full">
 			<!-- Graph section -->
-			<div class="w-full lg:w-1/2 p-4 flex flex-col items-center justify-center">
-				{{ .ChartHTML }}
-			</div>
-
+			{{ template "line_chart" . }}
 			<!-- Weigh-in form -->
 			<div id="new_weigh_in" class="w-full lg:w-1/2 p-4 flex flex-col items-center justify-center">
 				{{ template "weigh_in_form" . }}
@@ -28,4 +25,11 @@
 </body>
 
 </html>
+{{ end }}
+
+{{ block "line_chart" . }}
+<div class="w-full lg:w-1/2 p-4 flex flex-col items-center justify-center" hx-get="/get_chart_data"
+	hx-trigger="submit_weigh_in from:body delay:500ms" hx-swap="outerHTML">
+	{{ .ChartHTML }}
+</div>
 {{ end }}

--- a/templates/weigh_in_form.html
+++ b/templates/weigh_in_form.html
@@ -63,7 +63,7 @@
 
 		<!-- Submit Button -->
 		<div>
-			<button type="submit"
+			<button type="submit" onclick="document.body.dispatchEvent(new Event('submit_weigh_in'))"
 				class="w-full flex items-center justify-center gap-3 px-5 py-3 text-white font-semibold rounded-xl bg-blue-500 hover:bg-blue-700">
 				Submit
 			</button>


### PR DESCRIPTION
add an htmx trigger to refresh the weigh line chart after submitting a new weigh in. It's currently set on a 500ms delay.  I separated the line chart div to a template for ease of passing data through another handler.